### PR TITLE
2474 updates

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -180,9 +180,9 @@ class Driver(object):
 
         self.opt_result = {
             'runtime': 0.0,
-            'iter_count': 1,
-            'obj_calls': 1,
-            'deriv_calls': 1,
+            'iter_count': 0,
+            'obj_calls': 0,
+            'deriv_calls': 0,
             'exit_status': 'NOT_RUN'
         }
 
@@ -625,7 +625,7 @@ class Driver(object):
         int
             Number of objective evaluations made during a driver run.
         """
-        return 1
+        return 0
 
     def get_driver_derivative_calls(self):
         """
@@ -636,7 +636,7 @@ class Driver(object):
         int
             Number of derivative evaluations made during a driver run.
         """
-        return 1
+        return 0
 
     def get_design_var_values(self, get_remote=True, driver_scaling=True):
         """

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -1340,7 +1340,6 @@ class SaveOptResult(object):
         *args : array
             Solver recording requires extra args.
         """
-        print("exiting...")
         driver = self._driver
         driver.opt_result = {
             'runtime': time.time() - self._start_time,

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -1330,12 +1330,17 @@ class SaveOptResult(object):
         """
         Set start time for the driver run.
 
+        This uses 'perf_counter()' which gives "the value (in fractional seconds)
+        of a performance counter, i.e. a clock with the highest available resolution
+        to measure a short duration. It does include time elapsed during sleep and
+        is system-wide."
+
         Returns
         -------
         self : object
             self
         """
-        self._start_time = time.time()
+        self._start_time = time.perf_counter()
         return self
 
     def __exit__(self, *args):
@@ -1349,7 +1354,7 @@ class SaveOptResult(object):
         """
         driver = self._driver
         driver.opt_result = {
-            'runtime': time.time() - self._start_time,
+            'runtime': time.perf_counter() - self._start_time,
             'iter_count': driver.iter_count,
             'obj_calls': driver.get_driver_objective_calls(),
             'deriv_calls': driver.get_driver_derivative_calls(),

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -1311,6 +1311,13 @@ class SaveOptResult(object):
     ----------
     driver : Driver
         The driver.
+
+    Attributes
+    ----------
+    _driver : Driver
+        The driver for which we are saving results.
+    _start_time : float
+        The start time used to compute the run time.
     """
 
     def __init__(self, driver):

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -17,7 +17,7 @@ import scipy.sparse as sparse
 
 from openmdao.core.constants import _SetupStatus
 from openmdao.core.component import Component
-from openmdao.core.driver import Driver, record_iteration
+from openmdao.core.driver import Driver, record_iteration, SaveOptResult
 from openmdao.core.group import Group, System
 from openmdao.core.total_jac import _TotalJacInfo
 from openmdao.core.constants import _DEFAULT_OUT_STREAM, _UNDEFINED
@@ -808,7 +808,9 @@ class Problem(object):
             record_model_options(self, self._run_counter)
 
             self.model._clear_iprint()
-            return self.driver.run()
+
+            with SaveOptResult(self.driver):
+                return self.driver.run()
         finally:
             self._recording_iter.prefix = old_prefix
 

--- a/openmdao/drivers/differential_evolution_driver.py
+++ b/openmdao/drivers/differential_evolution_driver.py
@@ -50,6 +50,8 @@ class DifferentialEvolutionDriver(Driver):
         design variables.
     _ga : <DifferentialEvolution>
         Main genetic algorithm lies here.
+    _nfit : int
+         Number of successful function evaluations.
     _randomstate : int
         Seed-number which controls the random draws.
     """
@@ -76,6 +78,7 @@ class DifferentialEvolutionDriver(Driver):
 
         self._desvar_idx = {}
         self._ga = None
+        self._nfit = 0
 
         # random state can be set for predictability during testing
         if 'DifferentialEvolutionDriver_seed' in os.environ:

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -266,7 +266,7 @@ class pyOptSparseDriver(Driver):
         int
             Number of objective evaluations made during a driver run.
         """
-        return self.pyopt_solution.userObjCalls if self.pyopt_solution else 0
+        return self.pyopt_solution.userObjCalls if self.pyopt_solution else None
 
     def get_driver_derivative_calls(self):
         """
@@ -277,7 +277,7 @@ class pyOptSparseDriver(Driver):
         int
             Number of derivative evaluations made during a driver run.
         """
-        return self.pyopt_solution.userSensCalls if self.pyopt_solution else 0
+        return self.pyopt_solution.userSensCalls if self.pyopt_solution else None
 
     def run(self):
         """

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -266,7 +266,7 @@ class pyOptSparseDriver(Driver):
         int
             Number of objective evaluations made during a driver run.
         """
-        return self.pyopt_solution.userObjCalls if self.pyopt_solution else None
+        return self.pyopt_solution.userObjCalls if self.pyopt_solution else 0
 
     def get_driver_derivative_calls(self):
         """
@@ -277,7 +277,7 @@ class pyOptSparseDriver(Driver):
         int
             Number of derivative evaluations made during a driver run.
         """
-        return self.pyopt_solution.userSensCalls if self.pyopt_solution else None
+        return self.pyopt_solution.userSensCalls if self.pyopt_solution else 0
 
     def run(self):
         """

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -233,7 +233,10 @@ class ScipyOptimizeDriver(Driver):
         int
             Number of objective evaluations made during a driver run.
         """
-        return self.result.nfev if self.result else 0
+        if self.result and hasattr(self.result, 'nfev'):
+            return self.result.nfev
+        else:
+            return None
 
     def get_driver_derivative_calls(self):
         """
@@ -247,7 +250,7 @@ class ScipyOptimizeDriver(Driver):
         if self.result and hasattr(self.result, 'njev'):
             return self.result.njev
         else:
-            return 0
+            return None
 
     def run(self):
         """

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -245,10 +245,9 @@ class ScipyOptimizeDriver(Driver):
             Number of derivative evaluations made during a driver run.
         """
         if self.result and hasattr(self.result, 'njev'):
-            njev = self.result.njev
+            return self.result.njev
         else:
-            njev = None
-        return njev
+            return 0
 
     def run(self):
         """

--- a/openmdao/visualization/opt_report/opt_report.py
+++ b/openmdao/visualization/opt_report/opt_report.py
@@ -194,15 +194,16 @@ pip install tabulate
                 driver.get_design_var_values(driver_scaling=driver_scaling)[abs_name]
 
         for abs_name, meta in prob.driver._cons.items():
+            prom_name = get_prom_name(abs_name)
+            cons_meta[prom_name] = meta
             if 'alias' in meta and meta['alias'] is not None:
                 # check to see if the abs_name is the alias
                 if abs_name == meta['alias']:
-                    prom_name = abs_name  # keyed on the alias
+                    prom_name = meta['name']
                 else:
                     raise ValueError("Absolute name of var was expected to be the alias")  # TODO ??
             else:
-                prom_name = get_prom_name(abs_name)
-            cons_meta[prom_name] = meta
+                continue
             cons_vals[prom_name] = \
                 driver.get_constraint_values(driver_scaling=driver_scaling)[abs_name]
 

--- a/openmdao/visualization/opt_report/opt_report.py
+++ b/openmdao/visualization/opt_report/opt_report.py
@@ -163,6 +163,14 @@ pip install tabulate
     # Collect data from the problem
     abs2prom = prob.model._var_abs2prom
 
+    def get_prom_name(abs_name):
+        if abs_name in abs2prom['input']:
+            return abs2prom['input'][abs_name]
+        elif abs_name in abs2prom['output']:
+            return abs2prom['output'][abs_name]
+        else:
+            return abs_name
+
     # Collect the entire array of array valued desvars and constraints (ignore indices)
     objs_vals = {}
     desvars_vals = {}
@@ -171,14 +179,6 @@ pip install tabulate
     objs_meta = {}
     desvars_meta = {}
     cons_meta = {}
-
-    def get_prom_name(abs_name):
-        if abs_name in abs2prom['input']:
-            return abs2prom['input'][abs_name]
-        elif abs_name in abs2prom['output']:
-            return abs2prom['output'][abs_name]
-        else:
-            return abs_name
 
     with prob.model._scaled_context_all():
         for abs_name, meta in driver._objs.items():
@@ -197,7 +197,7 @@ pip install tabulate
             if 'alias' in meta and meta['alias'] is not None:
                 # check to see if the abs_name is the alias
                 if abs_name == meta['alias']:
-                    prom_name = abs_name  # both meta and vals are keyed on the alias
+                    prom_name = abs_name  # keyed on the alias
                 else:
                     raise ValueError("Absolute name of var was expected to be the alias")  # TODO ??
             else:

--- a/openmdao/visualization/opt_report/opt_report.py
+++ b/openmdao/visualization/opt_report/opt_report.py
@@ -168,26 +168,28 @@ pip install tabulate
     desvars_vals = {}
     cons_vals = {}
 
-    objs_meta = _prom_name_dict(prob.driver._objs, abs2prom)
-    desvars_meta = _prom_name_dict(prob.driver._designvars, abs2prom)
-    cons_meta = _prom_name_dict(prob.driver._cons, abs2prom)
+    objs_meta = {}
+    desvars_meta = {}
+    cons_meta = {}
+
+    def get_prom_name(abs_name):
+        if abs_name in abs2prom['input']:
+            return abs2prom['input'][abs_name]
+        elif abs_name in abs2prom['output']:
+            return abs2prom['output'][abs_name]
+        else:
+            return abs_name
 
     with prob.model._scaled_context_all():
         for abs_name, meta in driver._objs.items():
-            prom_name = abs2prom['input'][abs_name] if abs_name in abs2prom['input'] else \
-                abs2prom['output'][abs_name]
-            objs_vals[prom_name] = driver.get_objective_values(driver_scaling=driver_scaling)[
-                abs_name]
+            prom_name = get_prom_name(abs_name)
+            objs_meta[prom_name] = meta
+            objs_vals[prom_name] = \
+                driver.get_objective_values(driver_scaling=driver_scaling)[abs_name]
 
         for abs_name, meta in driver._designvars.items():
-
-            if abs_name in abs2prom['input']:
-                prom_name = abs2prom['input'][abs_name]
-            elif abs_name in abs2prom['output']:
-                prom_name = abs2prom['output'][abs_name]
-            else:
-                prom_name = abs_name
-
+            prom_name = get_prom_name(abs_name)
+            desvars_meta[prom_name] = meta
             desvars_vals[prom_name] = \
                 driver.get_design_var_values(driver_scaling=driver_scaling)[abs_name]
 
@@ -195,17 +197,12 @@ pip install tabulate
             if 'alias' in meta and meta['alias'] is not None:
                 # check to see if the abs_name is the alias
                 if abs_name == meta['alias']:
-                    prom_name = meta['name']
+                    prom_name = abs_name  # both meta and vals are keyed on the alias
                 else:
                     raise ValueError("Absolute name of var was expected to be the alias")  # TODO ??
             else:
-                if abs_name in abs2prom['input']:
-                    prom_name = abs2prom['input'][abs_name]
-                elif abs_name in abs2prom['output']:
-                    prom_name = abs2prom['output'][abs_name]
-                else:
-                    continue
-
+                prom_name = get_prom_name(abs_name)
+            cons_meta[prom_name] = meta
             cons_vals[prom_name] = \
                 driver.get_constraint_values(driver_scaling=driver_scaling)[abs_name]
 
@@ -752,34 +749,6 @@ def _constraint_plot(kind, meta, val, width=300):
     plt.close()
 
     return html
-
-
-def _prom_name_dict(d, abs2prom):
-    """
-    Convert values in dict to use promoted names.
-
-    Parameters
-    ----------
-    d : dict
-        A dictionary whose keys are absolute names, for which we want the promoted names.
-    abs2prom : dict
-        A mapping from absolute name to promoted name.
-
-    Returns
-    -------
-    dict
-        A dictionary identical to d, except the keys have been converted to promoted names.
-    """
-    ret = {}
-    for abs_name, meta in d.items():
-        if abs_name in abs2prom['input']:
-            prom_name = abs2prom['input'][abs_name]
-        elif abs_name in abs2prom['output']:
-            prom_name = abs2prom['output'][abs_name]
-        else:
-            prom_name = abs_name
-        ret[prom_name] = meta
-    return ret
 
 
 def _indicate_value_is_derived_from_array(derived_value, original_value):

--- a/openmdao/visualization/opt_report/opt_report.py
+++ b/openmdao/visualization/opt_report/opt_report.py
@@ -202,8 +202,6 @@ pip install tabulate
                     prom_name = meta['name']
                 else:
                     raise ValueError("Absolute name of var was expected to be the alias")  # TODO ??
-            else:
-                continue
             cons_vals[prom_name] = \
                 driver.get_constraint_values(driver_scaling=driver_scaling)[abs_name]
 

--- a/openmdao/visualization/opt_report/tests/test_opt_report.py
+++ b/openmdao/visualization/opt_report/tests/test_opt_report.py
@@ -133,7 +133,7 @@ class TestOptimizationReport(unittest.TestCase):
                                           cons_lower=0, cons_upper=10.,
                                           optimizer='COBYLA',
                                           )
-        self.check_opt_result(expected={'deriv_calls': 0})
+        self.check_opt_result(expected={'deriv_calls': None})
         opt_report(self.prob.driver)
 
     @require_pyoptsparse('SNOPT')

--- a/openmdao/visualization/opt_report/tests/test_opt_report.py
+++ b/openmdao/visualization/opt_report/tests/test_opt_report.py
@@ -47,7 +47,13 @@ class TestOptimizationReport(unittest.TestCase):
         prob.driver = driver()
 
         if optimizer:
-            self.prob.driver.options['optimizer'] = optimizer
+            driver_opts = self.prob.driver.options
+            driver_opts['optimizer'] = optimizer
+            # silence scipy & pyoptsparse
+            if 'disp' in driver_opts:
+                driver_opts['disp'] = False
+            if 'print_results' in driver_opts:
+                driver_opts['print_results'] = False
 
         prob.model.add_design_var('x', lower=vars_lower, upper=vars_upper)
         prob.model.add_design_var('y', lower=vars_lower, upper=vars_upper)
@@ -68,6 +74,7 @@ class TestOptimizationReport(unittest.TestCase):
 
         prob.driver = om.pyOptSparseDriver()
         prob.driver.options['optimizer'] = "SLSQP"
+        prob.driver.options['print_results'] = False
         prob.driver.opt_settings['ACC'] = 1e-13
         prob.set_solver_print(level=0)
         prob.model.add_constraint('con2', upper=0.0)

--- a/openmdao/visualization/opt_report/tests/test_opt_report.py
+++ b/openmdao/visualization/opt_report/tests/test_opt_report.py
@@ -75,6 +75,30 @@ class TestOptimizationReport(unittest.TestCase):
 
         return prob
 
+    def check_opt_result(self, opt_result=None, expected=None):
+        if opt_result is None:
+            opt_result = self.prob.driver.opt_result
+        if expected is None:
+            expected = {}
+
+        self.assertTrue(opt_result['runtime'] > 0)
+
+        self.assertTrue(opt_result['iter_count'] == expected['iter_count'] if 'iter_count' in expected
+                        else opt_result['iter_count'] >= 1,
+                        f"Unexpected value for iter_count: {opt_result['iter_count']}")
+
+        self.assertTrue(opt_result['obj_calls'] == expected['obj_calls'] if 'obj_calls' in expected
+                        else opt_result['obj_calls'] >= 1,
+                        f"Unexpected value for obj_calls: {opt_result['obj_calls']}")
+
+        self.assertTrue(opt_result['deriv_calls'] == expected['deriv_calls'] if 'deriv_calls' in expected
+                        else opt_result['deriv_calls'] >= 1,
+                        f"Unexpected value for deriv_calls: {opt_result['deriv_calls']}")
+
+        self.assertTrue(opt_result['exit_status'] == expected['exit_status'] if 'exit_status' in expected
+                        else opt_result['exit_status'] == 'SUCCESS',
+                        f"Unexpected value for exit_status: {opt_result['exit_status']}")
+
     def test_opt_report_check_file_created(self):
         self.setup_problem_and_run_driver(Driver,
                                           vars_lower=-50, vars_upper=50.,
@@ -91,6 +115,7 @@ class TestOptimizationReport(unittest.TestCase):
                                           vars_lower=-50, vars_upper=50.,
                                           cons_lower=-1,
                                           )
+        self.check_opt_result(expected={'obj_calls': 0, 'deriv_calls': 0})
         opt_report(self.prob.driver)
 
     def test_opt_report_scipyopt_SLSQP(self):
@@ -99,9 +124,39 @@ class TestOptimizationReport(unittest.TestCase):
                                           cons_lower=0, cons_upper=10.,
                                           optimizer='SLSQP',
                                           )
+        self.check_opt_result()
         opt_report(self.prob.driver)
 
-    def test_opt_report_scipyopt_DOE(self):
+    def test_opt_report_scipyopt_COBYLA(self):
+        self.setup_problem_and_run_driver(om.ScipyOptimizeDriver,
+                                          vars_lower=-50, vars_upper=50.,
+                                          cons_lower=0, cons_upper=10.,
+                                          optimizer='COBYLA',
+                                          )
+        self.check_opt_result(expected={'deriv_calls': 0})
+        opt_report(self.prob.driver)
+
+    @require_pyoptsparse('SNOPT')
+    def test_opt_report_pyoptsparse_snopt(self):
+        self.setup_problem_and_run_driver(om.pyOptSparseDriver,
+                                          vars_lower=-50, vars_upper=50.,
+                                          cons_lower=0, cons_upper=10.,
+                                          optimizer='SNOPT'
+                                          )
+        self.check_opt_result()
+        opt_report(self.prob.driver)
+
+    @require_pyoptsparse('SLSQP')
+    def test_opt_report_pyoptsparse_SLSQP(self):
+        self.setup_problem_and_run_driver(om.pyOptSparseDriver,
+                                          vars_lower=-50, vars_upper=50.,
+                                          cons_lower=0, cons_upper=10.,
+                                          optimizer='SLSQP'
+                                          )
+        self.check_opt_result()
+        opt_report(self.prob.driver)
+
+    def test_opt_report_DOE(self):
         # no report should be generated for this
         import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
@@ -125,6 +180,8 @@ class TestOptimizationReport(unittest.TestCase):
         prob.run_driver()
         prob.cleanup()
 
+        self.check_opt_result(prob.driver.opt_result, expected={'obj_calls': 0, 'deriv_calls': 0})
+
         expected_warning_msg = "The optimizer report is not applicable for the DOEDriver Driver " \
                                "which does not support optimization"
         with assert_warning(DriverWarning, expected_warning_msg):
@@ -132,37 +189,12 @@ class TestOptimizationReport(unittest.TestCase):
         outfilepath = str(pathlib.Path(prob.get_reports_dir()).joinpath(_default_optimizer_report_filename))
         self.assertFalse(os.path.exists(outfilepath))
 
-    def test_opt_report_scipyopt_COBYLA(self):
-        self.setup_problem_and_run_driver(om.ScipyOptimizeDriver,
-                                          vars_lower=-50, vars_upper=50.,
-                                          cons_lower=0, cons_upper=10.,
-                                          optimizer='COBYLA',
-                                          )
-        opt_report(self.prob.driver)
-
-    @require_pyoptsparse('SNOPT')
-    def test_opt_report_pyoptsparse_snopt(self):
-        self.setup_problem_and_run_driver(om.pyOptSparseDriver,
-                                          vars_lower=-50, vars_upper=50.,
-                                          cons_lower=0, cons_upper=10.,
-                                          optimizer='SNOPT'
-                                          )
-        opt_report(self.prob.driver)
-
-    @require_pyoptsparse('SLSQP')
-    def test_opt_report_pyoptsparse_SLSQP(self):
-        self.setup_problem_and_run_driver(om.pyOptSparseDriver,
-                                          vars_lower=-50, vars_upper=50.,
-                                          cons_lower=0, cons_upper=10.,
-                                          optimizer='SLSQP'
-                                          )
-        opt_report(self.prob.driver)
-
     def test_opt_report_genetic_algorithm(self):
         self.setup_problem_and_run_driver(om.SimpleGADriver,
                                           vars_lower=-50, vars_upper=50.,
                                           cons_lower=0, cons_upper=10.,
                                           )
+        self.check_opt_result(expected={'deriv_calls': 0})
         opt_report(self.prob.driver)
 
     def test_opt_report_differential_evolution(self):
@@ -189,6 +221,8 @@ class TestOptimizationReport(unittest.TestCase):
         prob.set_val('exec.x', np.linspace(-10, 10, 101))
 
         prob.run_driver()
+
+        self.check_opt_result(prob.driver.opt_result, expected={'deriv_calls': 0})
         opt_report(prob.driver)
 
     # Next test all the different variations of variable types (scalar and array) for both

--- a/openmdao/visualization/opt_report/tests/test_opt_report.py
+++ b/openmdao/visualization/opt_report/tests/test_opt_report.py
@@ -89,7 +89,7 @@ class TestOptimizationReport(unittest.TestCase):
             expected = {}
 
         self.assertTrue(opt_result['runtime'] > 0.0,
-                        f"Unexpected value for runtime: {opt_result['runtime']} (should be > 0.0")
+                        f"Unexpected value for runtime: {opt_result['runtime']} (should be > 0.0)")
 
         self.assertTrue(opt_result['iter_count'] == expected['iter_count'] if 'iter_count' in expected
                         else opt_result['iter_count'] >= 1,

--- a/openmdao/visualization/opt_report/tests/test_opt_report.py
+++ b/openmdao/visualization/opt_report/tests/test_opt_report.py
@@ -88,7 +88,8 @@ class TestOptimizationReport(unittest.TestCase):
         if expected is None:
             expected = {}
 
-        self.assertTrue(opt_result['runtime'] > 0)
+        self.assertTrue(opt_result['runtime'] > 0.0,
+                        f"Unexpected value for runtime: {opt_result['runtime']} (should be > 0.0")
 
         self.assertTrue(opt_result['iter_count'] == expected['iter_count'] if 'iter_count' in expected
                         else opt_result['iter_count'] >= 1,


### PR DESCRIPTION
### Summary

- use a context manager to save driver `opt_result` data
- use `perf_counter()` to time driver run (`time()` doesn't have enough resolution on Windows)
- default to zero counts for driver iter, obj & deriv calls
- initialize & document `_nfit` attribute in DE driver
- consistently return `None` if `nfev` or `njev` not returned by Scipy `optimize`
- streamline logic in `opt_report` to not iterate through objs, desvars and cons and compute `prom_name`  multiple times
- add check of `opt_result` dict to `opt_report` tests

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
