### PR TITLE
move opt_report hook to Problem.run_driver, add test

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -42,7 +42,7 @@ from openmdao.utils.hooks import _setup_hooks
 from openmdao.utils.indexer import indexer
 from openmdao.utils.record_util import create_local_meta
 from openmdao.utils.reports_system import get_reports_to_activate, activate_reports, \
-    clear_reports, get_reports_dir, _load_report_plugins, _active_reports
+    clear_reports, get_reports_dir, _load_report_plugins
 from openmdao.utils.general_utils import ContainsAll, pad_name, _is_slicer_op, LocalRangeIterable, \
     _find_dict_meta
 from openmdao.utils.om_warnings import issue_warning, DerivativesWarning, warn_deprecation, \

--- a/openmdao/visualization/opt_report/opt_report.py
+++ b/openmdao/visualization/opt_report/opt_report.py
@@ -101,22 +101,23 @@ _ellipse_height = 0.15
 
 
 def _optimizer_report_register():
-    register_report('optimizer', opt_report, 'Summary of optimization', 'Driver', 'run', 'post')
+    register_report('optimizer', opt_report, 'Summary of optimization',
+                    'Problem', 'run_driver', 'post')
 
 
-def opt_report(driver, outfile=None):
+def opt_report(prob, outfile=None):
     """
     Write a summary of the optimization to the given file.
 
     Parameters
     ----------
-    driver : Driver
-        The Driver for which the optimization report is being generated.
+    prob : Problem
+        The Problem for which the optimization report is being generated.
     outfile : str or None
         The path to the HTML file to be written.  If None (default), write to the default report
         output path.
     """
-    prob = driver._problem()
+    driver = prob.driver
     if not driver.supports['optimization']:
         driver_class = type(driver).__name__
         issue_warning(f"The optimizer report is not applicable for the {driver_class} Driver "


### PR DESCRIPTION
### Summary

- move the opt_report hook to Problem.run_driver
- add test to check that opt report is gets the correct data when run via the hook
- add additional checks of the report content to existing tests

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
